### PR TITLE
Fix PHP warning Undefined array key "plugin-init"

### DIFF
--- a/src/archives-calendar.php
+++ b/src/archives-calendar.php
@@ -84,7 +84,8 @@ function arcw_plugin_action_links( $links ) {
 
 function archivesCalendar_jquery_plugin() {
 	global $archivesCalendar_options;
-	$jQarcw = $archivesCalendar_options['plugin-init'] == 1 ? '/admin/js/jquery.arcw-init.js' : '/admin/js/jquery.arcw.js';
+	$pluginInit = isset($archivesCalendar_options['plugin-init']) ? $archivesCalendar_options['plugin-init'] : null;
+	$jQarcw = $pluginInit == 1 ? '/admin/js/jquery.arcw-init.js' : '/admin/js/jquery.arcw.js';
 	wp_register_script( 'jquery-arcw', plugins_url( $jQarcw, __FILE__ ), array( "jquery" ), ARCWV );
 	wp_enqueue_script( 'jquery-arcw' );
 }


### PR DESCRIPTION
Hi @alekart, thanks for this nice plugin!

When checking the Wordpress PHP logs, I saw that the plugin causes PHP warnings on every page load.

```
[Mon Aug 07 12:08:30.282173 2023] [proxy_fcgi:error] [pid 33031] [client 192.168.1.2:33674] AH01071: Got error 'PHP message: PHP Warning:  Undefined array key "plugin-init" in /var/www/project/wp-content/plugins/archives-calendar-widget/arw-settings.php on line 274'
```
This PR should fix the warning.