### PR TITLE
Fixes for PHP 8.0

### DIFF
--- a/src/arw-settings.php
+++ b/src/arw-settings.php
@@ -175,8 +175,6 @@ function sideBox() {
 }
 
 /* theme list select */
-// PHP 8.0 fix - David Green STH (30/08/2022)
-// Deprecated: Required parameter $args follows optional parameter $selected
 function arcw_themes_list($selected, $args)
 {
 	global $wpdb, $themes, $archivesCalendar_options;

--- a/src/arw-settings.php
+++ b/src/arw-settings.php
@@ -175,7 +175,9 @@ function sideBox() {
 }
 
 /* theme list select */
-function arcw_themes_list($selected = 0, $args)
+// PHP 8.0 fix - David Green STH (30/08/2022)
+// Deprecated: Required parameter $args follows optional parameter $selected
+function arcw_themes_list($selected, $args)
 {
 	global $wpdb, $themes, $archivesCalendar_options;
 

--- a/src/arw-widget.php
+++ b/src/arw-widget.php
@@ -292,7 +292,7 @@ function archives_month_view( $args, $sql ) {
 	$todayMonth = intval( date( 'm', $today ) );
 	$todayYear  = intval( date( 'Y', $today ) );
 
-	if ( is_archive() ) {
+	if ( is_archive() && $post != null ) {
 		$archiveYear  = intval( date( 'Y', strtotime( $post->post_date ) ) );
 		$archiveMonth = intval( date( 'm', strtotime( $post->post_date ) ) );
 
@@ -477,7 +477,10 @@ function archives_month_view( $args, $sql ) {
 	return $cal;
 }
 
-function get_calendar_header( $view = 'months', $pages, $archiveMonth = null, $archiveYear, $args ) {
+function get_calendar_header( $view, $pages, $archiveMonth, $archiveYear, $args ) {
+	if(empty($view)) { 
+		$view = 'months';
+	}
 	global $wp_locale;
 	extract( $args );
 	$cal = "\n<!-- Archives Calendar Widget by Aleksei Polechin - alek´ - http://alek.be -->\n";


### PR DESCRIPTION
The plugin generates the following warning messages when using PHP 8.0 or above:

- Deprecated: Required parameter $args follows optional parameter $selected
- Warning: Attempt to read property "post_date" on null
- Deprecated: Required parameter $pages follows optional parameter $view
- Deprecated: Required parameter $archiveYear follows optional parameter $view

Thanks to David Green, this pull request includes the fixes made by STH to make the plugin compatible with PHP 8.0, 
